### PR TITLE
clarifies when instructor info shows up

### DIFF
--- a/source/ch-introduction/sec-instructor-intro.ptx
+++ b/source/ch-introduction/sec-instructor-intro.ptx
@@ -33,7 +33,7 @@ xmlns:xi="http://www.w3.org/2001/XInclude"
 </p>
 
 <p>
-	For example an instructor note will appear below in the <em>instructor-web</em> and <em>instructor-print</em> versions of the document but it will not appear in the <em>web</em> or <em>print</em> versions.
+	For example an instructor note will appear below in the <em>instructor-web</em>, <em>instructor-print</em>, <em>web</em> and <em>print</em> versions of the document but it will not appear in the  <em>student-web</em> or <em>student-print</em> versions.
 	<commentary component="instructor">
 	<tabular top="major" bottom="major" left="major" right="major">
     <col width="100%" />


### PR DESCRIPTION
**Pull Request Description**

Clarifies that instructor notes appear in the `instructor` versions and in the `web` and `print` versions.  It appears in the `web` and `print` versions so that they can be seen in the CodeChat preview.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.