### PR TITLE
Fix build info for Vscode versions

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -10,9 +10,9 @@
     <target name="instructor-web-linux" format="html" publication="publication-instructor-linux.ptx"/>
     <target name="instructor-print-linux" format="pdf" publication="publication-instructor-linux.ptx"/>
 
-    <target name="student-web-vscode" format="html" publication="publication-student-linux.ptx"/>
-    <target name="student-print-vscode" format="pdf" publication="publication-student-linux.ptx"/>
-    <target name="instructor-web-vscode" format="html" publication="publication-instructor-linux.ptx"/>
-    <target name="instructor-print-vsdcode" format="pdf" publication="publication-instructor-linux.ptx"/>
+    <target name="student-web-vscode" format="html" publication="publication-student-vscode.ptx"/>
+    <target name="student-print-vscode" format="pdf" publication="publication-student-vscode.ptx"/>
+    <target name="instructor-web-vscode" format="html" publication="publication-instructor-vscode.ptx"/>
+    <target name="instructor-print-vsdcode" format="pdf" publication="publication-instructor-vscode.ptx"/>
   </targets>
 </project>

--- a/project.ptx
+++ b/project.ptx
@@ -13,6 +13,6 @@
     <target name="student-web-vscode" format="html" publication="publication-student-vscode.ptx"/>
     <target name="student-print-vscode" format="pdf" publication="publication-student-vscode.ptx"/>
     <target name="instructor-web-vscode" format="html" publication="publication-instructor-vscode.ptx"/>
-    <target name="instructor-print-vsdcode" format="pdf" publication="publication-instructor-vscode.ptx"/>
+    <target name="instructor-print-vscode" format="pdf" publication="publication-instructor-vscode.ptx"/>
   </targets>
 </project>


### PR DESCRIPTION
**Pull Request Description**

Fixes the references to the publication files that are used for the vscode versions in `project.ptx`.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.