### PR TITLE
makes exercise/task refs into links in instructor guide

### DIFF
--- a/source/ch-instructor-guide/sec-instructor-communities.ptx
+++ b/source/ch-instructor-guide/sec-instructor-communities.ptx
@@ -171,47 +171,56 @@
     xml:id="topic-communities-exercise-notes">
     <title>Exercise Notes</title>
     <p>
-      TODO: Update - THE NOTE FOR EXERCISE 2.3.2.1 DOESN'T SEEM TO BE NEEDED ANYMORE
       <ul>
         <li>
-          <title component="linux-kit-client">
-            <xref ref="ex-find-clone-url-linux" /> 
-          </title>
-          <title component="vscode-kit-client">
-            <xref ref="ex-create-kit-client-vscode-b" />
-          </title>
+          <em>
+            <p component="linux-kit-client">
+              <xref ref="ex-find-clone-url-linux" /> 
+            </p>
+            <p component="vscode-kit-client">
+              <xref ref="ex-create-kit-client-vscode-b" />
+            </p>
+          </em>
           <p>
             Some students will try to clone the upstream GitKit-FarmData2 repository instead of their origin repository.  A few may even attempt to clone the real FarmData2 repository.  The Kit-tty should prevent this and provide a helpful tip.
           </p>
         </li>
         <li>
-          <title>
-            <xref ref="ex-check-remotes" /> 
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-check-remotes" /> 
+            </p>
+          </em>
           <p>
             Checking the origin remote that is given as the answer to this question will confirm that the student has correctly cloned their origin.  Again, the Kit-tty should prevent them doing this incorrectly, but if somehow it did not catching and correcting this early is important.
           </p>
         </li>
         <li>
-          <title>
-            <xref ref="ex-identifying-assigned-issues" />
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-identifying-assigned-issues" />
+            </p>
+          </em>
           <p>
             The answer to this question will reasonably differ depending upon when students complete the exercise.  There are initially 3 issues that are pre-assigned to the user that deployed the GitKit.  Students who complete the exercise early are likely to all identify these issues. As additional students claim issues, other students will identify those claimed issues as well.
           </p>
         </li>
         <li>
-          <title>
-            <xref ref="ex-claim-an-issue" />
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-claim-an-issue" />
+            </p>
+          </em>
           <p>
             The activity instructs students to claim an issue by commenting on it with the very specific phrase "I would like to work on this please!"  If they are the first to do so the issue will be assigned to them and they will receive a personalized message from a one of the community automations in response. If they are not the first to respond, they will also receive a message to that effect and a suggestion to try a different issue.  It is important that they use the exact message given in the assignment, otherwise the community automation will not recognize and respond to the question.
           </p>
         </li>
         <li>
-          <title>
-            <xref ref="topic-extra-practice-communities" />
-          </title>
+          <em>
+            <p>
+              <xref ref="topic-extra-practice-communities" />
+            </p>
+          </em>
           <p>
             Some students will attempt to clone the project that they select while they are inside the GitKit-FarmData2 repository that they already cloned.  If they do attempt this the Kit-tty should intervene, prevent the action and respond with a helpful message.
           </p>

--- a/source/ch-instructor-guide/sec-instructor-merge-conflicts.ptx
+++ b/source/ch-instructor-guide/sec-instructor-merge-conflicts.ptx
@@ -183,38 +183,45 @@
     xml:id="topic-merge-conflicts-exercise-notes">
     <title>Exercise Notes</title>
     <p>
-      TODO: Update ARE THE TITLES GOOD DESCRIPTORS? 
       <ul>
         <li>
-          <title>
-            Structural vs Logical/Semanitic Conflicts
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-merge-conflicts-practice-2-e" />- <xref ref="ex-merge-conflicts-practice-2-f" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-merge-conflicts-practice-2-e" />, <xref ref="ex-merge-conflicts-practice-2-f" />. In this exercise there are no conflicting changes and the merge would be able to be completed automatically.  However, if all of the non-conflicting changes are merged into the result the program will not produce the correct result.  The point being that automatic merges can check for structural conflicts, but not logical or semantic conflicts and thus caution should be used when performing merges.
+            In this exercise there are no conflicting changes and the merge would be able to be completed automatically.  However, if all of the non-conflicting changes are merged into the result the program will not produce the correct result.  The point being that automatic merges can check for structural conflicts, but not logical or semantic conflicts and thus caution should be used when performing merges.
           </p>
         </li>
         <li>
-          <title>
-            No Conflicts in PR
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-no-automatic-merge-on-github" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-no-automatic-merge-on-github" />. Inevitably some students will be behind on their work and will complete their sync with upstream <code>main</code> after you have merged the PR for the <code>addRound2Conflicts</code> branch.  In these cases, their pull requests will not create a conflict to be resolved.  These students should follow the instructions given in <xref ref="topic-appendix-a-merge-conflicts" />.  These directions have them pull the <code>mergeConflictPractice</code> branch and create a pull request for it.  That PR will then contain conflicts with the changes in the <code>addRound2Conflicts</code> branch that was merged into <code>main</code>.  They will then complete the activity using the <code>mergeConflictPractice</code> branch as it it were their feature branch. Students not in this situation, but who would like additional practice can also pull and use the <code>mergeConflictPractice</code> branch at the end of the activity.
+            Inevitably some students will be behind on their work and will complete their sync with upstream <code>main</code> after you have merged the PR for the <code>addRound2Conflicts</code> branch.  In these cases, their pull requests will not create a conflict to be resolved.  These students should follow the instructions given in <xref ref="topic-appendix-a-merge-conflicts" />.  These directions have them pull the <code>mergeConflictPractice</code> branch and create a pull request for it.  That PR will then contain conflicts with the changes in the <code>addRound2Conflicts</code> branch that was merged into <code>main</code>.  They will then complete the activity using the <code>mergeConflictPractice</code> branch as it it were their feature branch. Students not in this situation, but who would like additional practice can also pull and use the <code>mergeConflictPractice</code> branch at the end of the activity.
           </p>
         </li>
         <li>
-          <title>
-            Merge Tool Common Ancestor
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-launch-mergetool" />.
+            </p>
+          </em>
           <p>
-            <xref ref="ex-launch-mergetool" />. By default, VS Code does not display the best common ancestor in its merge tool. The steps given in these questions has the students change the VS Code configuration such that it includes the best common ancestor.
+            By default, VS Code does not display the best common ancestor in its merge tool. The steps given in these questions has the students change the VS Code configuration such that it includes the best common ancestor.
           </p>
         </li>
         <li>
-          <title>
-            Extra Practice
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-extra-practice-merging-fetch-repo" />.
+            </p>
+          </em>
           <p>
-            <xref ref="ex-extra-practice-merging-fetch-repo" />. If the student did not need to use the <code>merge-conflict-practice</code> branch in <xref ref="ex-no-automatic-merge-on-github" />, then they can use it at this point for additional practice with resolving merge conflicts.
+            If the student did not need to use the <code>merge-conflict-practice</code> branch in <xref ref="ex-no-automatic-merge-on-github" />, then they can use it at this point for additional practice with resolving merge conflicts.
           </p>
         </li>
       </ul>

--- a/source/ch-instructor-guide/sec-instructor-synchronization.ptx
+++ b/source/ch-instructor-guide/sec-instructor-synchronization.ptx
@@ -180,42 +180,48 @@
     xml:id="topic-synchronizing-exercise-notes">
     <title>Exercise Notes</title>
     <p>
-      TODO: Update ARE THE TITLES GOOD DESCRIPTORS?
-
       <ul>
         <li>
-          <title>
-            Late Forks
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-origin-main-behind-main-a" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-origin-main-behind-main-a" />. If a student begins the GitKit activities late they may make their fork and clone after the "Round 1" issues have been merged. This will result in their origin <code>main</code> branch not being <term>behind</term> the upstream <code>main</code> branch.  The directions in <xref ref="topic-appendix-a-staying-synchronized"/> of the activity have them reset the <code>HEAD</code> of their <code>main</code> branch to the commit before any "Round 1" issues were merged. Once they force push this change to their origin they will then see that their <code>main</code> branch is behind the upstream <code>main</code> as expected.
+            If a student begins the GitKit activities late they may make their fork and clone after the "Round 1" issues have been merged. This will result in their origin <code>main</code> branch not being <term>behind</term> the upstream <code>main</code> branch.  The directions in <xref ref="topic-appendix-a-staying-synchronized"/> of the activity have them reset the <code>HEAD</code> of their <code>main</code> branch to the commit before any "Round 1" issues were merged. Once they force push this change to their origin they will then see that their <code>main</code> branch is behind the upstream <code>main</code> as expected.
           </p>
         </li>
         <li>
-          <title>
-            Check Remote Upstream
-          </title>
-          <p component="vscode-kit-client">
-            <xref ref="ex-setting-upstream-b-vscode" />. It is a good idea to check here that the student's upstream remote points to the correct GitKit-FarmData2 repository.  The Kit-tty should have caught this error and directed students on the correct way to set the upstream remote. However, some students have still managed to set their upstream to point to their origin or to the live FarmData2 repository.
-          </p>
-          <p component="linux-kit-client">
-            <xref ref="ex-setting-upstream-e-linux" />. It is a good idea to check here that the student's upstream remote points to the correct GitKit-FarmData2 repository.  The Kit-tty should have caught this error and directed students on the correct way to set the upstream remote. However, some students have still managed to set their upstream to point to their origin or to the live FarmData2 repository.
+          <em>
+            <p component="vscode-kit-client">
+              <xref ref="ex-setting-upstream-b-vscode" />
+            </p>
+            <p component="linux-kit-client">
+              <xref ref="ex-setting-upstream-e-linux" />
+            </p>
+          </em>
+          <p>
+            It is a good idea to check here that the student's upstream remote points to the correct GitKit-FarmData2 repository.  The Kit-tty should have caught this error and directed students on the correct way to set the upstream remote. However, some students have still managed to set their upstream to point to their origin or to the live FarmData2 repository.
           </p>
         </li>
         <li>
-          <title>
-            Claiming Round 2 Issues
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-claim-issue-b" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-claim-issue-b" />. After synchronizing with the upstream, the students go on to find a "Round2" ticket in the issue tracker. There are only 4 "Round2" issues, so multiple students will be working on each one.  This question requests that they comment on the issue they want to work on but should spread themselves across the available "Round 2" issues.  If you like you can manually assign each "Round2" issue to all students who commented on it, though this is not necessary.
+            After synchronizing with the upstream, the students go on to find a "Round2" ticket in the issue tracker. There are only 4 "Round2" issues, so multiple students will be working on each one.  This question requests that they comment on the issue they want to work on but should spread themselves across the available "Round 2" issues.  If you like you can manually assign each "Round2" issue to all students who commented on it, though this is not necessary.
           </p>
         </li>
         <li>
-          <title>
-            Fixing Round 2 Issues
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-fixing-issue-ordering" /> - <xref ref="ex-pull-request-info" />.
+            </p>
+          </em>
           <p>
-            <xref ref="ex-fixing-issue-ordering" /> - <xref ref="ex-pull-request-info" />. These questions ask the student to use the forking workflow to create a fix for the "Round 2" ticket on which they chose to work. GitHub will indicate that the PRs created by each student for their "Round 2" issue can be merged automatically.  This is because even though multiple students are working on each "Round 2" issue, none of them will have been merged into the upstream <code>main</code> at this point. When introducing <xref ref="topic-resolving-a-merge-conflict" /> the instructor will merge a branch that creates conflicts with all of the student "Round2" PRs.
+            These questions ask the student to use the forking workflow to create a fix for the "Round 2" ticket on which they chose to work. GitHub will indicate that the PRs created by each student for their "Round 2" issue can be merged automatically.  This is because even though multiple students are working on each "Round 2" issue, none of them will have been merged into the upstream <code>main</code> at this point. When introducing <xref ref="topic-resolving-a-merge-conflict" /> the instructor will merge a branch that creates conflicts with all of the student "Round2" PRs.
           </p>
         </li>
       </ul>

--- a/source/ch-instructor-guide/sec-instructor-upstreaming.ptx
+++ b/source/ch-instructor-guide/sec-instructor-upstreaming.ptx
@@ -134,39 +134,45 @@
     xml:id="topic-upstreaming-exercise-notes">
     <title>Exercise Notes</title>
     <p>
-      TODO: update. ARE THE TITLES GOOD DESCRIPTORS? Using the title tag means the reference isn't a clickable link.
-
       <ul>
         <li>
-          <title>
-            Checking Repository Status
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-understanding-project-history" /> 
+            </p>
+          </em>
           <p>
-            <xref ref="ex-understanding-project-history" />. If a student is seeing commit dates, usernames and messages that differ from the correct answers then it is likely that they created their fork after PRs were merged at the start of <xref ref="topic-staying-synchronized" />.  Other than difficulty answering these questions this will not cause an issue with continuing with this chapter. Issues will arise with the exercises in <xref ref="topic-staying-synchronized"/> and <xref ref="topic-resolving-a-merge-conflict"/>. Each of those chapters provide the students with instructions for resolving the issues at the point where they arise.
+            If a student is seeing commit dates, usernames and messages that differ from the correct answers then it is likely that they created their fork after PRs were merged at the start of <xref ref="topic-staying-synchronized" />.  Other than difficulty answering these questions this will not cause an issue with continuing with this chapter. Issues will arise with the exercises in <xref ref="topic-staying-synchronized"/> and <xref ref="topic-resolving-a-merge-conflict"/>. Each of those chapters provide the students with instructions for resolving the issues at the point where they arise.
           </p>
         </li>
         <li>
-          <title>
-            Checking File Changed
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-verify-changes" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-verify-changes" />.The <code>git status</code> command here should show one untracked file with modifications and that file should agree with the file that they identified in <xref ref="ex-claimed-issue-url" />.
+            The <code>git status</code> command here should show one untracked file with modifications and that file should agree with the file that they identified in <xref ref="ex-claimed-issue-url" />.
           </p>
         </li>
         <li>
-          <title>
-            Checking Commit
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-committing-changes-d" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-committing-changes-d" />. This question is a good checkpoint to ensure that they have done things correctly to this point.  The most recent commit in the <code>git log</code> output should show that they committed changes to the correct file (i.e. the one from <xref ref="ex-claimed-issue-url" />) and that they have used a meaningful commit message.
+            This question is a good checkpoint to ensure that they have done things correctly to this point.  The most recent commit in the <code>git log</code> output should show that they committed changes to the correct file (i.e. the one from <xref ref="ex-claimed-issue-url" />) and that they have used a meaningful commit message.
           </p>
         </li>
         <li>
-          <title>
-            Checking PR format
-          </title>
+          <em>
+            <p>
+              <xref ref="ex-pull-request-find" />
+            </p>
+          </em>
           <p>
-            <xref ref="ex-pull-request-find" />. The instructor can use the link provided here to check the students' pull requests for several points:
+            The instructor can use the link provided here to check the students' pull requests for several points:
             <ul>
               <li>
                 <p>


### PR DESCRIPTION
**Pull Request Description**

Changes the use of `title` tags to `p` tags within the `li` tags that make up the comments on different exercises.  When the `title` tag was used the exercise/task name was displayed but it was not a link.  Using a `p` tag allows them to be links.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.