### PR TITLE
try changing the document-id to gitkit linux

### DIFF
--- a/source/docinfo.ptx
+++ b/source/docinfo.ptx
@@ -5,9 +5,9 @@
 <!-- settings. -->
 <docinfo xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- A unique name for the book in a catalog; for example, see https://pretextbook.org/catalog.html and https://runestone.academy/ns/books/index. It contains a simple lowercase string with no dashes or other special characters. See https://pretextbook.org/doc/guide/html/sec-publishing-to-runestone-academy.html for more information. -->
-  <document-id>gitkit</document-id>
+  <document-id>gitkitlinux</document-id>
   <!-- A brief description for the book in a catalog; see the links above. The @shelf is used only when publishing to Runestone; see https://runestone.academy/ns/books/index for a list of valid values. You must copy these @shelf names exactly, including capitalization. -->
-  <blurb shelf="Misc"> A hands-on introduction to Open Source collaboration using a git/gitHub forking workflow. </blurb>
+  <blurb shelf="Misc"> A hands-on introduction to Open Source collaboration using a git/gitHub forking workflow in a Linux desktop environment. </blurb>
 
   <!-- The next three lines are likely for mature projects only: -->
 

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -5,7 +5,7 @@
   <xi:include href="./docinfo.ptx" />
 
   <book xml:id="the-gitkit-book">
-    <title>GitKit</title>
+    <title>GitKit (Linux Desktop Edition)</title>
     <subtitle>Learn git and GitHub in Context</subtitle>
 
     <!-- Include frontmatter -->


### PR DESCRIPTION
**Pull Request Description**

It would be nice for the document id to reflect the version, so this PR is an attempt to change the `document-id` in the `dockinfo.ptx` file for the linux version of the text.  The question is whether Runestone will pick it up when the repo is changed or if we'll need to create a new book using the new id?

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.