### PR TITLE
move runestone output to unique dir for linux edition

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -15,9 +15,9 @@
   "name": "PreTeXt-Codespaces",
 
   // This Docker image includes some LaTeX support, but is still not to large.  Note that if you keep your codespace running, it will use up your GitHub free storage quota.  Additional options are listed below.
-  // "image": "oscarlevin/pretext:small",
+  "image": "oscarlevin/pretext:small",
   // If you need to generate more complicated assets (such as sageplots) or use additional fonts when building to PDF, comment out the above line and uncomment the following line.
-  "image": "oscarlevin/pretext:full",
+  // "image": "oscarlevin/pretext:full",
   // If you only intend to build for web and don't have any latex-image generated assets, you can use a smaller image:
   // "image": "oscarlevin/pretext:lite",
 

--- a/.github/workflows/pretext-cli.yml
+++ b/.github/workflows/pretext-cli.yml
@@ -24,21 +24,8 @@ jobs:
             - name: install deps
               run: pip install -r requirements.txt
 
-            - name: install local ptx files
-              run: pretext --version
-
             - name: build deploy targets
-              run: |
-                version="$(pretext --version)"
-                major="$(echo $version | cut -d '.' -f 1)"
-                minor="$(echo $version | cut -d '.' -f 2)"
-                if [ "$major" -ge 2 -a "$minor" -ge 5 ]; then
-                    echo "PreTeXt version is 2.5 or greater; using new build command"
-                    pretext build --deploys
-                else
-                    echo "PreTeXt version is less than 2.5, using old build command"
-                    pretext build
-                fi
+              run: pretext build --deploys
             - name: stage deployment
               run: pretext deploy --stage-only
 

--- a/project.ptx
+++ b/project.ptx
@@ -7,7 +7,7 @@
 
     <!-- This is the target that is built on runestone -->
     <!-- It will need to be made to point to the vscode publication file in the fork for that edition. -->
-    <target name="runestone" format="html" publication="publication-runestone-linux.ptx" output-dir="publication/gitkit" />
+    <target name="runestone" format="html" publication="publication-runestone-linux.ptx" output-dir="runestone-linux" />
     
     <!--
     <target name="runestone-linux" format="html" publication="publication-runestone-linux.ptx" output-dir="publication/gitkit" />

--- a/project.ptx
+++ b/project.ptx
@@ -7,6 +7,7 @@
 
     <!-- This is the target that is built on runestone -->
     <!-- It will need to be made to point to the vscode publication file in the fork for that edition. -->
+    <!-- The output-dir should also be changed to a unique directory for the VSCode version. -->
     <target name="runestone" format="html" publication="publication-runestone-linux.ptx" output-dir="runestone-linux" />
     
     <!--


### PR DESCRIPTION
**Pull Request Description**

Changes the output directory for the runestone linux edition to a directory that is unique to that edition.  This is an attempt to fix a build issue on Runestone where the VSCode edition was still building the Linux edition.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.