### PR TITLE
fix the output directory for runestone target

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -8,7 +8,7 @@
     <!-- This is the target that is built on runestone -->
     <!-- It will need to be made to point to the vscode publication file in the fork for that edition. -->
     <!-- The output-dir should also be changed to a unique directory for the VSCode version. -->
-    <target name="runestone" format="html" publication="publication-runestone-linux.ptx" output-dir="runestone-linux" />
+    <target name="runestone" format="html" publication="publication-runestone-linux.ptx" output-dir="published/gitkitlinux" />
     
     <!--
     <target name="runestone-linux" format="html" publication="publication-runestone-linux.ptx" output-dir="publication/gitkit" />


### PR DESCRIPTION
**Pull Request Description**

Sets the output of the runestone target to be `published/gitkitlinux` as described in the pretext author guide.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.