### PR TITLE
escape . in regular expressions

### DIFF
--- a/source/ch-communities-and-collaboration/sec-development-environment.ptx
+++ b/source/ch-communities-and-collaboration/sec-development-environment.ptx
@@ -407,21 +407,21 @@
         </statement>
         <setup>
           <var>
-            <condition string='^git config --global user.name "[^&lt;].+[^&gt;]"$'>
+            <condition string='^git config --global user\.name "[^&lt;].+[^&gt;]"$'>
               <feedback>
                 <p>
                   This command will set the name associated with your changes in git.
                 </p>
               </feedback>
             </condition>
-            <condition string='^git config --global user.name ["]*&lt;.+&gt;["]*$'>
+            <condition string='^git config --global user\.name ["]*&lt;.+&gt;["]*$'>
               <feedback>
                 <p>
                   You should not include the &lt; and &gt; in your command.
                 </p>
               </feedback>
             </condition>
-            <condition string='^git config --global user.name [^"].+[^"]$'>
+            <condition string='^git config --global user\.name [^"].+[^"]$'>
               <feedback>
                 <p>
                   Be sure to use quotation marks around your name.
@@ -455,28 +455,28 @@
         </statement>
         <setup>
           <var>
-            <condition string='^git config --global user.email "[^&lt;].+@.+[^&gt;]"$'>
+            <condition string='^git config --global user\.email "[^&lt;].+@.+[^&gt;]"$'>
               <feedback>
                 <p>
                   This command will set the email associated with your changes in git.
                 </p>
               </feedback>
             </condition>
-            <condition string='^git config --global user.email "[^&lt;][^@]+[^&gt;]"$'>
+            <condition string='^git config --global user\.email "[^&lt;][^@]+[^&gt;]"$'>
               <feedback>
                 <p>
                   Be sure you have entered a valid email address.
                 </p>
               </feedback>
             </condition>
-            <condition string='^git config --global user.email ["]*&lt;.+&gt;["]*$'>
+            <condition string='^git config --global user\.email ["]*&lt;.+&gt;["]*$'>
               <feedback>
                 <p>
                   You should not include the &lt; and &gt; in your command.
                 </p>
               </feedback>
             </condition>
-            <condition string='^git config --global user.email [^"].+[^"]$'>
+            <condition string='^git config --global user\.email [^"].+[^"]$'>
               <feedback>
                 <p>
                   Be sure to use quotation marks around your email.


### PR DESCRIPTION
**Pull Request Description**

Escapes the . in regular expression checks for `user.name` and `user.email`.

Closes #121 
Closes #122 

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.