### PR TITLE
fix bad xrefs in ch5

### DIFF
--- a/source/ch-merge-conflicts/sec-resolving-a-merge-conflict.ptx
+++ b/source/ch-merge-conflicts/sec-resolving-a-merge-conflict.ptx
@@ -461,7 +461,7 @@
         </blocks>
         <hint>
           <p>
-            See <xref ref="topic-staging-changes" /> and <xref ref="source/ch-upstreaming-changes/sec-committing-to-your-local-repository.ptx" /> for a review.
+            See <xref ref="topic-staging-changes" /> and <xref ref="topic-committing-to-your-local-repository" /> for a review.
           </p>
         </hint>      
       </exercise>


### PR DESCRIPTION
**Pull Request Description**

Patches a bad xref in chapter 5.

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.