### PR TITLE
clarifies uses of GitKit FarmData2 folder or repository

### DIFF
--- a/source/ch-communities-and-collaboration/sec-cloning-your-origin.ptx
+++ b/source/ch-communities-and-collaboration/sec-cloning-your-origin.ptx
@@ -630,10 +630,10 @@
   </subsection>
 
 <subsection xml:id="topic-open-repo-folder">
-  <title>Opening the GitKit-FarmData2 Repository Folder</title>
+  <title>Opening the GitKit FarmData2 Repository Folder</title>
   
   <p>
-  You cloned your GitKit-FarmData2 respitory into a folder in your development environment with the command in <xref ref="ex-clone-origin-linux-a" />.
+    You cloned your fork of the GitKit FarmData2 upstream repository into a folder in your development environment with the command in <xref ref="ex-clone-origin-linux-a" />.
   </p>
 
   <p>
@@ -646,7 +646,7 @@
   <exercise xml:id="ex-open-repo-folder" label="ex-open-repo-folder">
   <statement>
     <p>
-      Open the GitKit-FarmData2 folder.
+      Open your clone of the GitKit FarmData2 repository.
     </p>
     <p>
       You can do this by going to the "hamburger" (&#8801;) menu in the upper left of your development environment window.
@@ -655,7 +655,7 @@
       Choose <c>File > Open Folder...</c>
     </p>
     <p>
-      Select the <c>GitKit-FarmData2</c> folder and click <c>OK</c>.
+      Select the folder containing your clone of the <c>GitKit FarmData2</c> and click <c>OK</c>.
     </p>
     <p>
       You will see <c>Setting up your Codespace</c>, and then your terminal will show a message from the <term>Kit-tty</term>.

--- a/source/ch-instructor-guide/sec-instructor-communities.ptx
+++ b/source/ch-instructor-guide/sec-instructor-communities.ptx
@@ -24,7 +24,7 @@
         </li>
         <li>
           <p>
-            Fork the upstream `GitKit-FarmData2` repository into their own GitHub space.
+            Fork the upstream of the GitKit FarmData2 repository into their own GitHub space.
           </p>
         </li>
         <li>
@@ -34,7 +34,7 @@
         </li>
         <li>
           <p>
-            Clone their fork (i.e. their origin) of the `GitKit-FarmData2` repository.
+            Clone their fork (i.e. their origin) of the GitKit FarmData2 repository.
           </p>
         </li>
       </ol>
@@ -146,7 +146,7 @@
             The slides conclude with a short introduction to the idea of an issue tracker and its role in a project. The use of the issue tracker tends to be fairly intuitive and the hands-on activities walk students through some of the details. The hands-on activity has each student claim an issue that is labeled as "Round 1." Note that they claim the issue in this activity, but do not fix it until the next activity. Each of these issues asks them to fix a typo that appears in one of the Markdown (<c>.md</c>) files in the root directory of the project.
           </p>
           <p>
-            If time permits, a live demo looking at the issue tracker in the upstream GitKit-FarmData2 repository, pointing out the "Round 1" label and how to tell if an issue has been assigned. Note that several of the issues will have been pre-assigned to whomever deployed the kit.
+            If time permits, a live demo looking at the issue tracker in the upstream GitKit FarmData2 repository, pointing out the "Round 1" label and how to tell if an issue has been assigned. Note that several of the issues will have been pre-assigned to whomever deployed the kit.
           </p>
         </li>
       </ul>
@@ -179,7 +179,7 @@
             </p>
           </em>
           <p>
-            Some students will give the URL of the upstream GitKit-FarmData2 repository for the course instead of their origin repository.  A few may even give the URL of a real FarmData2 upstream repository.
+            Some students will give the URL of the upstream GitKit FarmData2 repository for the course instead of their origin repository.  A few may even give the URL of a real FarmData2 upstream repository.
           </p>
         </li>
         <li>
@@ -189,7 +189,7 @@
             </p>
           </em>
           <p>
-            Some students will try to clone the upstream GitKit-FarmData2 repository for the course or even give the URL of a real FarmData2 upstream repository.
+            Some students will try to clone the upstream GitKit FarmData2 repository for the course or even give the URL of a real FarmData2 upstream repository.
           </p>
         </li>
         <li>
@@ -219,7 +219,7 @@
             </p>
           </em>
           <p>
-            Some students will attempt to clone the project that they select while they are inside the GitKit-FarmData2 repository that they already cloned.  If they do attempt this the Kit-tty should intervene, prevent the action and respond with a helpful message.
+            Some students will attempt to clone the project that they select while they are inside the directory containing their local GitKit FarmData2 repository.  If they do attempt this the Kit-tty should intervene, prevent the action and respond with a helpful message.
           </p>
         </li>
       </ul>

--- a/source/ch-instructor-guide/sec-instructor-synchronization.ptx
+++ b/source/ch-instructor-guide/sec-instructor-synchronization.ptx
@@ -198,7 +198,7 @@
             </p>
           </em>
           <p>
-            It is a good idea to check here that the student's upstream remote points to the correct GitKit-FarmData2 repository.  The Kit-tty should have caught this error and directed students on the correct way to set the upstream remote. However, some students have still managed to set their upstream to point to their origin or to the live FarmData2 repository.
+            It is a good idea to check here that the student's upstream remote points to the correct GitKit FarmData2 repository.  The Kit-tty should have caught this error and directed students on the correct way to set the upstream remote. However, some students have still managed to set their upstream to point to their origin or to the live FarmData2 repository.
           </p>
         </li>
         <li>

--- a/source/ch-instructor-guide/sec-instructor-upstreaming.ptx
+++ b/source/ch-instructor-guide/sec-instructor-upstreaming.ptx
@@ -7,7 +7,7 @@
   <title>Working Locally and Upstreaming Changes Instructor Notes</title>
   <introduction>
     <p>
-      This chapter focuses on the upstreaming process.  Students learn about feature branches, staging and committing changes, pushing feature branches to their origin repository, and making a pull request. At the end of the hands-on activity each student will have experienced the full forking workflow, resulting in a pull request to the upstream GitKit-FarmData2 repository for changes that fix the "Round 1" issue that they were assigned.  The "Round 1" issues have been created such that they do not conflict with each other.  Thus, all of the student pull requests should be able to be merged automatically.  The instructor will typically perform these merges as a demonstration at the start of the class introducing <xref ref="topic-staying-synchronized" />.
+      This chapter focuses on the upstreaming process.  Students learn about feature branches, staging and committing changes, pushing feature branches to their origin repository, and making a pull request. At the end of the hands-on activity each student will have experienced the full forking workflow, resulting in a pull request to the upstream GitKit FarmData2 repository for changes that fix the "Round 1" issue that they were assigned.  The "Round 1" issues have been created such that they do not conflict with each other.  Thus, all of the student pull requests should be able to be merged automatically.  The instructor will typically perform these merges as a demonstration at the start of the class introducing <xref ref="topic-staying-synchronized" />.
     </p>
     <p>
       The exercises in this chapter have the students perform the following major tasks:

--- a/source/ch-staying-synchronized/sec-appendix-a.ptx
+++ b/source/ch-staying-synchronized/sec-appendix-a.ptx
@@ -16,7 +16,7 @@
   </p>
 
   <p>
-    Ensure that you are in the <em>GitKit-FarmData2</em> directory then use the following commands:
+    Ensure that you are in the directory for your local clone of your <em>GitKit FarmData2</em> repository then use the following commands:
     <ol>
       <li>
         <c>git switch main</c>

--- a/source/ch-upstreaming-changes/sec-exploring-your-local-repository.ptx
+++ b/source/ch-upstreaming-changes/sec-exploring-your-local-repository.ptx
@@ -151,8 +151,7 @@
     <task xml:id="ex-understanding-project-history-new-aa" label="ex-understanding-project-history-new-aa">
       <statement>
         <p>
-          Ensure that you are in your cloned repo (i.e.
-          the <em>GitKit-FarmData2</em> directory is your working directory).
+          Ensure that you are in the directory containing your cloned GitKit FarmData2 repository (use the <c>cd</c> command if necessary).
           Then use the <c>git log</c> command from <xref ref="ex-understanding-project-history-new-a"/> to display the information about the 4 most recent commits.
           (If you don't see all four recent commits, press "return" or "spacebar" to see more; when you are done, press "q" to quit.)
         </p>
@@ -509,7 +508,7 @@
   <introduction>
     <p>
       The <c>git status</c> command provides the current status of your local repository.
-      Use the <c>git status</c> command to see the current status of your local <em>GitKit-FarmData2</em> repository.
+      Use the <c>git status</c> command to see the current status of your local GitKit FarmData2 repository.
     </p>
   </introduction>
 


### PR DESCRIPTION
**Pull Request Description**

Clarifies locations where "GitKit-FarmData2" were used because instructors may have given their upstream repository a different name.  Text now uses more generic phrases such as "the directory for your local GitKit FarmData2" repository or "the GitKit FarmData2 upstream repository".

Closes #176

---

**Licensing Certification**

GitKit is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.